### PR TITLE
spike:  declaring typed queries outside of CTE `with` calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": true
+}

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,6 @@
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",
-    "kysely": "npm:kysely@^0.27.5"
+    "kysely": "npm:kysely"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@std/assert@1": "1.0.11",
     "jsr:@std/internal@^1.0.5": "1.0.5",
+    "npm:kysely@*": "0.27.5",
     "npm:kysely@~0.27.5": "0.27.5"
   },
   "jsr": {
@@ -24,7 +25,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
-      "npm:kysely@~0.27.5"
+      "npm:kysely@*"
     ]
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -6,7 +6,7 @@ import {
   PostgresQueryCompiler,
   QueryCreator,
   SelectQueryBuilder,
-} from "npm:kysely";
+} from "kysely";
 
 export interface Person {
   dogId: string;
@@ -38,10 +38,18 @@ interface Query<T> {
 
 const charlesses: Query<Person> = ({ selectFrom }) =>
   selectFrom("people").where("name", "=", "Charles").selectAll();
+
 const pauls: Query<Person> = ({ selectFrom }) =>
   selectFrom("people").where("name", "=", "Paul").selectAll();
 
+// this works because () => pauls(db) delays execution
+// db.with("charles", charlesses) does not modify db itself; it returns a new Kysely instance with an extended type
+// if pauls is passed directly, it would be checked against the original db, which does not include { charles: Person }, causing a type mismatch
+// wrapping pauls(db) in a function ensures it is evaluated with the new instance that includes { charles: Person }, making it compatible
 db.with("charles", charlesses).with("pauls", () => pauls(db));
 
-//this works at runtime, but the query interface cannot accept QueryCreator<DB & { extended: Thing }>
+// this fails because pauls is explicitly typed as Query<Person>, which means it expects QueryCreator<DB>
+// however, db.with("charles", charlesses) does not modify db but instead returns a new Kysely instance with an extended type
+// when pauls is passed directly, it is still expecting QueryCreator<DB>, but it is now being used with Kysely<DB & { charles: Person }>
+// this causes a type mismatch because QueryCreator<DB> is not assignable to QueryCreator<DB & { charles: Person }>
 db.with("charles", charlesses).with("pauls", pauls);


### PR DESCRIPTION
Let me know if there is anything else I can explain by adding comments here or if I can update the comments on `main.ts`